### PR TITLE
chore: raise PR limits to match the shared preset

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -21,8 +21,10 @@
   "timezone": "America/New_York",
   "schedule": ["before 6am on monday"], // batch once a week → fewer CI runs
 
-  "prConcurrentLimit": 5,
-  "prHourlyLimit": 2,
+  // Kept in step with the shared preset (renovate-config#3). 45 updates were
+  // queued behind a limit of 5, which is ~9 weeks to clear this repo alone.
+  "prConcurrentLimit": 20,
+  "prHourlyLimit": 5,
   "rebaseWhen": "conflicted",
   "lockFileMaintenance": { "enabled": true, "schedule": ["before 6am on monday"] },
   "labels": ["dependencies"],


### PR DESCRIPTION
Mirrors [renovate-config#3](https://github.com/AISecurityAssurance/renovate-config/pull/3). This repo inlines its Renovate config rather than extending the shared preset — a public repo cannot fetch a private preset — so the change has to be applied here separately.

```diff
-  "prConcurrentLimit": 5,
-  "prHourlyLimit": 2,
+  "prConcurrentLimit": 20,
+  "prHourlyLimit": 5,
```

The Dependency Dashboard here has **45 updates in "Awaiting Schedule"** against a limit of 5 — roughly nine weeks to clear, and this repo holds 179 of the fleet's actionable alerts, the largest single share.

The weekly schedule is unchanged, so updates still land in one Monday batch. Security PRs were never throttled by either setting (`vulnerabilityAlerts` defaults to `prCreation: "immediate"` with an empty schedule), which is why #20 and #21 merged while those 45 sat queued.